### PR TITLE
feat: migrate flv decoder errors to pe.Action

### DIFF
--- a/Reply/decoder/flvDecode.go
+++ b/Reply/decoder/flvDecode.go
@@ -27,12 +27,14 @@ const (
 var (
 	flvHeaderSign = []byte{0x46, 0x4c, 0x56}
 
-	ErrNoFoundFlvHeader = errors.New("ErrNoFoundFlvHeader")
-	ErrNoFoundTagHeader = errors.New("ErrNoFoundTagHeader")
-	ErrTagSizeZero      = errors.New("ErrTagSizeZero")
-	ErrStreamId         = errors.New("ErrStreamId")
-	ErrTagSize          = errors.New("ErrTagSize")
-	ErrSignLost         = errors.New("ErrSignLost")
+	ActFlvDecoder = pe.Action[struct {
+		ErrNoFoundFlvHeader pe.Error
+		ErrNoFoundTagHeader pe.Error
+		ErrTagSizeZero      pe.Error
+		ErrStreamId         pe.Error
+		ErrTagSize          pe.Error
+		ErrSignLost         pe.Error
+	}](`ActFlvDecode`)
 
 	ActFlv = pe.Action[struct {
 		InitFlv        pe.Error
@@ -61,12 +63,12 @@ func (t *FlvDecoder) Init(buf []byte) (frontBuf []byte, dropOffset int, err erro
 	}
 
 	if buf[0] != flvHeaderSign[0] || buf[1] != flvHeaderSign[1] || buf[2] != flvHeaderSign[2] {
-		err = ErrNoFoundFlvHeader
+		err = ActFlvDecoder.ErrNoFoundFlvHeader
 		return
 	}
 
 	if buf[flvHeaderSize]|buf[flvHeaderSize+1]|buf[flvHeaderSize+2]|buf[flvHeaderSize+3] != 0 {
-		err = ErrTagSize
+		err = ActFlvDecoder.ErrTagSize
 		return
 	}
 
@@ -76,18 +78,18 @@ func (t *FlvDecoder) Init(buf []byte) (frontBuf []byte, dropOffset int, err erro
 			buf[bufOffset]&0b00011111 != videoTag &&
 				buf[bufOffset]&0b00011111 != audioTag &&
 				buf[bufOffset]&0b00011111 != scriptTag {
-			err = ErrNoFoundTagHeader
+			err = ActFlvDecoder.ErrNoFoundTagHeader
 			return
 		}
 
 		if buf[bufOffset+8]|buf[bufOffset+9]|buf[bufOffset+10] != streamId {
-			err = ErrStreamId
+			err = ActFlvDecoder.ErrStreamId
 			return
 		}
 
 		tagSize := int(F.Btoi32v2(buf[bufOffset+1:bufOffset+4], 0))
 		if tagSize == 0 {
-			err = ErrTagSizeZero
+			err = ActFlvDecoder.ErrTagSizeZero
 			return
 		}
 
@@ -97,7 +99,7 @@ func (t *FlvDecoder) Init(buf []byte) (frontBuf []byte, dropOffset int, err erro
 
 		tagSizeCheck := int(F.Btoi32v2(buf[bufOffset+tagHeaderSize+tagSize:bufOffset+tagHeaderSize+tagSize+previouTagSize], 0))
 		if tagNum != 0 && tagSizeCheck != tagSize+tagHeaderSize {
-			err = ErrTagSize
+			err = ActFlvDecoder.ErrTagSize
 			return
 		}
 
@@ -111,7 +113,7 @@ func (t *FlvDecoder) Init(buf []byte) (frontBuf []byte, dropOffset int, err erro
 			} else if (buf[bufOffset] == scriptTag) && (sign&0x01 == 0x00) {
 				sign |= 0x01
 			} else {
-				err = ErrSignLost
+				err = ActFlvDecoder.ErrSignLost
 				return
 			}
 			bufOffset += tagSizeCheck + previouTagSize
@@ -144,18 +146,18 @@ func (t *FlvDecoder) SearchStreamFrame(buf []byte, keyframe *slice.Buf[byte]) (d
 			buf[bufOffset]&0b00011111 != videoTag &&
 				buf[bufOffset]&0b00011111 != audioTag &&
 				buf[bufOffset]&0b00011111 != scriptTag {
-			err = ErrNoFoundTagHeader
+			err = ActFlvDecoder.ErrNoFoundTagHeader
 			return
 		}
 
 		if buf[bufOffset+8]|buf[bufOffset+9]|buf[bufOffset+10] != streamId {
-			err = ErrStreamId
+			err = ActFlvDecoder.ErrStreamId
 			return
 		}
 
 		tagSize := int(F.Btoi32v2(buf[bufOffset+1:bufOffset+4], 0))
 		if tagSize == 0 {
-			err = ErrTagSizeZero
+			err = ActFlvDecoder.ErrTagSizeZero
 			return
 		}
 		if bufOffset+tagHeaderSize+tagSize+previouTagSize > len(buf) {
@@ -164,7 +166,7 @@ func (t *FlvDecoder) SearchStreamFrame(buf []byte, keyframe *slice.Buf[byte]) (d
 
 		tagSizeCheck := int(F.Btoi32v2(buf[bufOffset+tagHeaderSize+tagSize:bufOffset+tagHeaderSize+tagSize+previouTagSize], 0))
 		if tagSizeCheck != tagSize+tagHeaderSize {
-			err = ErrTagSize
+			err = ActFlvDecoder.ErrTagSize
 			return
 		}
 
@@ -213,18 +215,18 @@ func (t *FlvDecoder) oneF(buf []byte, w ...dealFFlv) (dropOffset int, err error)
 			buf[bufOffset]&0b00011111 != videoTag &&
 				buf[bufOffset]&0b00011111 != audioTag &&
 				buf[bufOffset]&0b00011111 != scriptTag {
-			err = ErrNoFoundTagHeader
+			err = ActFlvDecoder.ErrNoFoundTagHeader
 			return
 		}
 
 		if buf[bufOffset+8]|buf[bufOffset+9]|buf[bufOffset+10] != streamId {
-			err = ErrStreamId
+			err = ActFlvDecoder.ErrStreamId
 			return
 		}
 
 		tagSize := int(F.Btoi32v2(buf[bufOffset+1:bufOffset+4], 0))
 		if tagSize == 0 {
-			err = ErrTagSizeZero
+			err = ActFlvDecoder.ErrTagSizeZero
 			return
 		}
 		if bufOffset+tagHeaderSize+tagSize+previouTagSize > len(buf) {
@@ -233,7 +235,7 @@ func (t *FlvDecoder) oneF(buf []byte, w ...dealFFlv) (dropOffset int, err error)
 
 		tagSizeCheck := int(F.Btoi32v2(buf[bufOffset+tagHeaderSize+tagSize:bufOffset+tagHeaderSize+tagSize+previouTagSize], 0))
 		if tagSizeCheck != tagSize+tagHeaderSize {
-			err = ErrTagSize
+			err = ActFlvDecoder.ErrTagSize
 			return
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/gorilla/websocket v1.5.3 // indirect
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.1
 	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/lib/pq v1.10.9
 	github.com/miekg/dns v1.1.68 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/mdp/qrterminal/v3 v3.2.0
-	github.com/qydysky/part v0.28.20260413163131
+	github.com/qydysky/part v0.28.20260417161007
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/text v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/qydysky/biliApi v0.0.0-20260226134054-aeb783162dab h1:/QYhfxCo1Quu9QM
 github.com/qydysky/biliApi v0.0.0-20260226134054-aeb783162dab/go.mod h1:AFTXs+mq7iF7TIPhsx6MR3UMbUIQJMCoKpemTxqZmTg=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a h1:OSIFTKGKsOLYycboWvW/1EvgPMinwtm2/IH+TE/zYrc=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a/go.mod h1:cI8/gy/wjy2Eb+p2IUj2ZuDnC8R5Vrx3O0VMPvMvphA=
-github.com/qydysky/part v0.28.20260413163131 h1:wJEKJpxfkaHvUEFg4Obe2CrFk91rDwfAEcCjKJNVNAw=
-github.com/qydysky/part v0.28.20260413163131/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
+github.com/qydysky/part v0.28.20260417161007 h1:r5E7RIyX6tO7GhejOlwMBwaTDHgWzHQi+AaT56u3SKc=
+github.com/qydysky/part v0.28.20260417161007/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
+github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=


### PR DESCRIPTION
Refactor flvDecode.go to replace standalone error variables with pe.Action[struct] for centralized error handling. This improves error context and aligns with the project's error management pattern.