### PR TITLE
Add 配置项 指定房间回调

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,55 @@
 
 关于离线构建，详见章节`运行`及其`注意事项`
 
+#### 指定房间回调
+在(>v0.20.19)，添加了`指定房间回调`配置项。
+
+其扩展了原配置项`指定房间录制回调`，`指定房间录制回调`将失效。
+
+```json
+{
+  "指定房间回调":[
+    {
+      "roomid-help": "指定房间号，0时禁用",
+      "roomid":0,
+      "runDir-help": "命令执行目录，为空时为本程序所在目录",
+      "runDir": "",
+      "begin-help": "当开播时触发命令",
+      "begin": [],
+      "fin-help": "当下播时触发命令",
+      "fin": [],
+      "titleChange-help": "当房间标题变化时触发，占位符{oldTitle}:旧标题(string) {newTitle}:新标题(string)",
+      "titleChange": [],
+      "afterRec-help": "当结束录制后(包含切片)触发对应的命令，占位符{liveDir}:录播所在目录(string)(末尾有/) {recSec}:录制时长秒数(uint)(>=0) {type}:视频类型(string)(例如mp4)",
+      "afterRec":[]
+    }
+  ]
+}
+```
+
+从`指定房间录制回调`升级，此处使用linux示例：
+```json
+{
+  "durationS":60,
+  "after":["ffmpeg","-i","0.{type}","-y","-c","copy","1.{type}"]
+}
+```
+->
+```json
+{
+  "runDir": "/xxxx/",
+  "afterRec":["./a.sh", "{liveDir}", "{recSec}", "{type}"]
+}
+```
+```sh
+/xxxx/a.sh
+#!/bin/bash
+if [ "$2" -gt 60 ]; then
+  cd $1
+  ffmpeg -i 0.$3 -y -c copy 1.$3
+fi
+```
+
 #### 节目单
 添加节目单功能(>v0.20.3)，用于将多个**按顺序的无缝录播目录**组合。
 
@@ -613,6 +662,8 @@ sqlite3:
 
 
 #### 指定房间录制回调
+在>v0.20.19，此配置作废，你可以使用`指定房间回调`进行等效替换
+
 配置文件添加了如下配置
 ```json
 {
@@ -793,16 +844,16 @@ I: 2022/09/15 02:23:23 Msg [qydysky丶 : 赞]
 
 当所选类型在当前直播中不可用时，会按以下顺序[`fmp4`,`flv`]尝试。
 
-Ass默认`utf-8`编码，在录播结束时生成，可以配合`指定房间录制回调`生成硬编码弹幕的视频，配置项如下(>v0.15.9)
+Ass默认`utf-8`编码，在录播结束时生成，可以配合`指定房间回调`生成硬编码弹幕的视频，配置项如下(>v0.15.9)
 
 ```json
 {
-  "指定房间录制回调":[
+  "指定房间回调":[
     {
       "roomid-help":"0替换为指定的房间号",
       "roomid":0,
-      "durationS":10,
-      "after":["ffmpeg","-i","0.{type}","-y","-vf","ass=0.ass","1.{type}"]
+      "afterRecSec":10,
+      "afterRec":["ffmpeg","-i","{liveDir}0.{type}","-y","-vf","ass=0.ass","{liveDir}1.{type}"]
     }
   ],
   "Ass": {

--- a/Reply/F/comp.go
+++ b/Reply/F/comp.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/qydysky/bili_danmu/Reply/F/lessDanmu"        //removable
 	_ "github.com/qydysky/bili_danmu/Reply/F/parseM3u8"
 	_ "github.com/qydysky/bili_danmu/Reply/F/rev"           //removable
+	_ "github.com/qydysky/bili_danmu/Reply/F/roomSignal"    //removable
 	_ "github.com/qydysky/bili_danmu/Reply/F/saveDanmuToDB" //removable
 	_ "github.com/qydysky/bili_danmu/Reply/F/saveToJson"    //removable
 	_ "github.com/qydysky/bili_danmu/Reply/F/shortDanmu"    //removable
@@ -25,6 +26,18 @@ import (
 	comp "github.com/qydysky/part/component2"
 	log "github.com/qydysky/part/log/v2"
 )
+
+type RoomSignalI interface {
+	FiliterRoomId(configs any, roomId int) interface {
+		LoginChange(isLogin bool) error
+		Begin() error
+		Fin() error
+		TitleChange(oldTitle, newTitle string) error
+		AfterRec(videoType string, liveDir string, duration time.Duration) error
+	}
+}
+
+var RoomSignal = comp.GetV3[RoomSignalI](`roomSignal`)
 
 var GenCpuPprof = comp.GetV3[interface {
 	Start(ctx context.Context, file string) (any, error)

--- a/Reply/F/roomSignal/roomSignal.go
+++ b/Reply/F/roomSignal/roomSignal.go
@@ -1,0 +1,184 @@
+package roomsignal
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	comp "github.com/qydysky/part/component2"
+	pe "github.com/qydysky/part/errors/v2"
+	fc "github.com/qydysky/part/funcCtrl"
+)
+
+type Inter interface {
+	FiliterRoomId(configs any, roomId int) interface {
+		LoginChange(isLogin bool) error
+		Begin() error
+		Fin() error
+		TitleChange(oldTitle, newTitle string) error
+		AfterRec(videoType string, liveDir string, duration time.Duration) error
+	}
+}
+
+func init() {
+	comp.RegisterOrPanic[Inter](`roomSignal`, impl{})
+}
+
+var ActRoomSignal = pe.Action[struct {
+	NoRoomFound pe.Error
+}](`ActRoomSignal`)
+
+type impl struct {
+	vm map[string]any
+}
+
+func (t impl) FiliterRoomId(configs any, roomId int) interface {
+	LoginChange(isLogin bool) error
+	Begin() error
+	Fin() error
+	TitleChange(oldTitle, newTitle string) error
+	AfterRec(videoType string, liveDir string, duration time.Duration) error
+} {
+	if v, ok := configs.([]any); ok {
+		for i := 0; i < len(v); i++ {
+			if vm, ok := v[i].(map[string]any); ok {
+				if roomid, ok := vm["roomid"].(float64); ok && int(roomid) == roomId {
+					t.vm = vm
+					break
+				}
+			}
+		}
+	}
+	return &t
+}
+
+var (
+	loginStateInit atomic.Bool
+	lastLoginState atomic.Bool
+	loginRunning   fc.SkipFunc
+)
+
+func (t *impl) LoginChange(isLogin bool) error {
+	if loginStateInit.CompareAndSwap(false, true) {
+		lastLoginState.Store(isLogin)
+		return nil
+	} else if lastLoginState.Swap(isLogin) == isLogin {
+		return nil
+	}
+	defer loginRunning.UnSet()
+	if loginRunning.NeedSkip() {
+		return nil
+	}
+
+	var (
+		loginChange, _ = t.vm["loginChange"].([]any)
+		runDir, _      = t.vm["runDir"].(string)
+	)
+	if len(loginChange) < 1 {
+		return nil
+	}
+	var cmds []string
+	for i := 0; i < len(loginChange); i++ {
+		if cmd, ok := loginChange[i].(string); ok && cmd != "" {
+			cmds = append(cmds, cmd)
+		}
+	}
+	cmd := exec.Command(cmds[0], cmds[1:]...)
+	cmd.Dir = runDir
+	return cmd.Run()
+}
+
+var beginRunning fc.SkipFunc
+
+func (t *impl) Begin() error {
+	defer beginRunning.UnSet()
+	if beginRunning.NeedSkip() {
+		return nil
+	}
+	var (
+		begin, _  = t.vm["begin"].([]any)
+		runDir, _ = t.vm["runDir"].(string)
+	)
+	if len(begin) < 1 {
+		return nil
+	}
+	var cmds []string
+	for i := 0; i < len(begin); i++ {
+		if cmd, ok := begin[i].(string); ok && cmd != "" {
+			cmds = append(cmds, cmd)
+		}
+	}
+	cmd := exec.Command(cmds[0], cmds[1:]...)
+	cmd.Dir = runDir
+	return cmd.Run()
+}
+
+var finRunning fc.SkipFunc
+
+func (t *impl) Fin() error {
+	defer finRunning.UnSet()
+	if finRunning.NeedSkip() {
+		return nil
+	}
+	var (
+		fin, _    = t.vm["fin"].([]any)
+		runDir, _ = t.vm["runDir"].(string)
+	)
+	if len(fin) < 1 {
+		return nil
+	}
+	var cmds []string
+	for i := 0; i < len(fin); i++ {
+		if cmd, ok := fin[i].(string); ok && cmd != "" {
+			cmds = append(cmds, cmd)
+		}
+	}
+	cmd := exec.Command(cmds[0], cmds[1:]...)
+	cmd.Dir = runDir
+	return cmd.Run()
+}
+
+func (t *impl) TitleChange(oldTitle, newTitle string) error {
+	var (
+		titleChange, _ = t.vm["titleChange"].([]any)
+		runDir, _      = t.vm["runDir"].(string)
+	)
+	if len(titleChange) < 1 {
+		return nil
+	}
+	var cmds []string
+	for i := 0; i < len(titleChange); i++ {
+		if cmd, ok := titleChange[i].(string); ok && cmd != "" {
+			cmd = strings.ReplaceAll(cmd, `{oldTitle}`, oldTitle)
+			cmd = strings.ReplaceAll(cmd, `{newTitle}`, newTitle)
+			cmds = append(cmds, cmd)
+		}
+	}
+	cmd := exec.Command(cmds[0], cmds[1:]...)
+	cmd.Dir = runDir
+	return cmd.Run()
+}
+
+func (t *impl) AfterRec(videoType string, liveDir string, duration time.Duration) error {
+	var (
+		after, _  = t.vm["afterRec"].([]any)
+		runDir, _ = t.vm["runDir"].(string)
+	)
+	if len(after) < 1 {
+		return nil
+	}
+	var cmds []string
+	for i := 0; i < len(after); i++ {
+		if cmd, ok := after[i].(string); ok && cmd != "" {
+			cmd = strings.ReplaceAll(cmd, `{type}`, videoType)
+			cmd = strings.ReplaceAll(cmd, `{liveDir}`, liveDir)
+			cmd = strings.ReplaceAll(cmd, `{recSec}`, fmt.Sprintf("%0.0f", duration.Seconds()))
+			cmds = append(cmds, cmd)
+		}
+	}
+	cmd := exec.Command(cmds[0], cmds[1:]...)
+	cmd.Dir = runDir
+	return cmd.Run()
+}

--- a/Reply/Reply.go
+++ b/Reply/Reply.go
@@ -970,7 +970,7 @@ func (t replyF) preparing(s []byte) {
 	if err := json.Unmarshal(s, &type_item); err != nil {
 		msglog.E(err)
 		return
-	} else {
+	} else if t.Liveing {
 		{ //附加功能 savestream结束
 			t.Liveing = false
 			// 停止此房间录制

--- a/Reply/Reply.go
+++ b/Reply/Reply.go
@@ -692,12 +692,19 @@ func (t replyF) room_change(s []byte) {
 	setTitle := StreamOCut(t.Roomid)
 
 	// 标题改变
-	if t.Title != type_item.Data.Title {
+	if oldTitle := t.Title; oldTitle != type_item.Data.Title {
 		t.Title = type_item.Data.Title
 		setTitle(t.Title)
 		var sh = []any{"标题改变", t.Title}
 		Gui_show(Itos(sh), "0room")
 		msglog.BaseAdd("房").I(sh...)
+
+		go replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
+			if e := inter.FiliterRoomId(t.K_v.LoadV("指定房间回调"), t.Roomid).TitleChange(oldTitle, t.Title); e != nil {
+				msglog.BaseAdd("房").W(e)
+			}
+		})
+
 	} else {
 		// 直播间标题引入审核机制，触发审核时会接收到一个roomchange但标题不变
 		tryS := 900.0
@@ -708,7 +715,6 @@ func (t replyF) room_change(s []byte) {
 		ctx, cancle := context.WithTimeout(context.Background(), time.Second*time.Duration(tryS))
 		roomChangeFC.FlashWithCallback(cancle)
 
-		oldTitle := t.Title
 		go func(ctx context.Context, roomid int) {
 			for t.Roomid == roomid {
 				select {
@@ -725,6 +731,13 @@ func (t replyF) room_change(s []byte) {
 							var sh = []any{"标题改变", t.Title}
 							Gui_show(Itos(sh), "0room")
 							msglog.BaseAdd("房").I(sh...)
+
+							go replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
+								if e := inter.FiliterRoomId(t.K_v.LoadV("指定房间回调"), t.Roomid).TitleChange(beforeTitle, t.Title); e != nil {
+									msglog.BaseAdd("房").W(e)
+								}
+							})
+
 							return
 						}
 					}
@@ -967,6 +980,11 @@ func (t replyF) preparing(s []byte) {
 			if _, e := liveOver.Sumup.Run(context.Background(), t.Common); e != nil {
 				msglog.E(e)
 			}
+			go replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
+				if e := inter.FiliterRoomId(t.K_v.LoadV(`指定房间回调`), roomId).Fin(); e != nil {
+					msglog.W("房间", type_item.Roomid, e)
+				}
+			})
 		}
 		Gui_show("房间", type_item.Roomid, "下播了", "0room")
 		msglog.I("房间", type_item.Roomid, "下播了")
@@ -1005,9 +1023,14 @@ func (t replyF) live(s []byte) {
 			}
 			//有时不返回弹幕 开播刷新弹幕
 			t.Danmu_Main_mq.Push_tag(`flash_room`, nil)
+			go replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
+				if e := inter.FiliterRoomId(t.K_v.LoadV(`指定房间回调`), type_item.Roomid).Begin(); e != nil {
+					msglog.W("房间", type_item.Roomid, e)
+				}
+			})
 		}()
 
-		Gui_show(Itos([]interface{}{"房间", type_item.Roomid, "开播了"}), "0room")
+		Gui_show(Itos([]any{"房间", type_item.Roomid, "开播了"}), "0room")
 		msglog.I("房间", type_item.Roomid, "开播了")
 	}
 }

--- a/Reply/stream.go
+++ b/Reply/stream.go
@@ -1594,36 +1594,41 @@ func (t *M4SStream) Start() bool {
 					}()
 				}
 
-				//指定房间录制回调
-				if v, ok := ms.common.K_v.LoadV("指定房间录制回调").([]any); ok && len(v) > 0 {
-					l := l.Base(`录制回调`)
-					for i := 0; i < len(v); i++ {
-						if vm, ok := v[i].(map[string]any); ok {
-							if roomid, ok := vm["roomid"].(float64); ok && int(roomid) == ms.common.Roomid {
-								var (
-									durationS, _ = vm["durationS"].(float64)
-									after, _     = vm["after"].([]any)
-								)
-								if len(after) >= 2 && durationS >= 0 && duration.Seconds() > durationS {
-									var cmds []string
-									for i := 0; i < len(after); i++ {
-										if cmd, ok := after[i].(string); ok && cmd != "" {
-											cmds = append(cmds, strings.ReplaceAll(cmd, "{type}", saveType))
-										}
-									}
-
-									cmd := exec.Command(cmds[0], cmds[1:]...)
-									cmd.Dir = savePath
-									l.I("启动", cmd.Args)
-									if e := cmd.Run(); e != nil {
-										l.E(e)
-									}
-									l.I("结束")
-								}
-							}
-						}
+				//指定房间回调
+				replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
+					if e := inter.FiliterRoomId(ms.common.K_v.LoadV("指定房间回调"), ms.common.Roomid).AfterRec(saveType, savePath, duration); e != nil {
+						l.E(e)
 					}
-				}
+				})
+				// if v, ok := ms.common.K_v.LoadV("指定房间录制回调").([]any); ok && len(v) > 0 {
+				// 	l := l.Base(`录制回调`)
+				// 	for i := 0; i < len(v); i++ {
+				// 		if vm, ok := v[i].(map[string]any); ok {
+				// 			if roomid, ok := vm["roomid"].(float64); ok && int(roomid) == ms.common.Roomid {
+				// 				var (
+				// 					durationS, _ = vm["durationS"].(float64)
+				// 					after, _     = vm["after"].([]any)
+				// 				)
+				// 				if len(after) >= 2 && durationS >= 0 && duration.Seconds() > durationS {
+				// 					var cmds []string
+				// 					for i := 0; i < len(after); i++ {
+				// 						if cmd, ok := after[i].(string); ok && cmd != "" {
+				// 							cmds = append(cmds, strings.ReplaceAll(cmd, "{type}", saveType))
+				// 						}
+				// 					}
+
+				// 					cmd := exec.Command(cmds[0], cmds[1:]...)
+				// 					cmd.Dir = savePath
+				// 					l.I("启动", cmd.Args)
+				// 					if e := cmd.Run(); e != nil {
+				// 						l.E(e)
+				// 					}
+				// 					l.I("结束")
+				// 				}
+				// 			}
+				// 		}
+				// 	}
+				// }
 				return false
 			})()
 		}

--- a/main/config/config_K_v.json
+++ b/main/config/config_K_v.json
@@ -132,17 +132,19 @@
             "danmu":""
         }
     ],
-    "指定房间录制回调-help":"当指定roomid的房间结束录制后(包含切片)触发对应的命令，命令执行目录为录播目录，占位符({type}:视频类型)，durationS：录制时长超过指定秒数才触发",
-    "指定房间录制回调":[
+    "指定房间回调-help":"指定roomid触发对应的命令",
+    "指定房间回调":[
         {
             "roomid":0,
-            "durationS":10,
-            "after":["cmd","/c","ffmpeg","-i","0.{type}","-y","-c","copy","1.{type}","1>1.log","2>&1"]
-        },
-        {
-            "roomid":0,
-            "durationS":10,
-            "after":["ffmpeg","-i","0.{type}","-y","-c","copy","1.{type}"]
+            "runDir": "",
+            "begin-help": "当开播时触发，命令执行目录为runDir",
+            "begin": [],
+            "fin-help": "当下播时触发，命令执行目录为runDir",
+            "fin": [],
+            "titleChange-help": "当房间标题变化时触发，命令执行目录为runDir，占位符{oldTitle}:旧标题 {newTitle}:新标题",
+            "titleChange": [],
+            "afterRec-help": "当结束录制后(包含切片)触发对应的命令，recSec:录制时长超过指定秒数才触发，占位符{liveDir}:录播所在目录 {recSec}:录制时长秒数(uint)(>=0) {type}:视频类型",
+            "afterRec":["ffmpeg","-i","{liveDir}0.{type}","-y","-c","copy","{liveDir}1.{type}"]
         }
     ],
     "指定房间录制区间-help":"指定roomid的房间在指定时间段内将会开启录制.start时检查是否在直播,是则开始录制,如已在录制则切片.end时停止录制.在开播时,若同时有start与end的fromTo,且当前在start与end之间,则录制,若无同时有start与end,则开播就录制。5s内只能触发一个fromTo",

--- a/main/config/config_K_v.json
+++ b/main/config/config_K_v.json
@@ -135,16 +135,18 @@
     "指定房间回调-help":"指定roomid触发对应的命令",
     "指定房间回调":[
         {
+            "roomid-help": "指定房间号，0时禁用",
             "roomid":0,
+            "runDir-help": "命令执行目录，为空时为本程序所在目录",
             "runDir": "",
-            "begin-help": "当开播时触发，命令执行目录为runDir",
+            "begin-help": "当开播时触发命令",
             "begin": [],
-            "fin-help": "当下播时触发，命令执行目录为runDir",
+            "fin-help": "当下播时触发命令",
             "fin": [],
-            "titleChange-help": "当房间标题变化时触发，命令执行目录为runDir，占位符{oldTitle}:旧标题 {newTitle}:新标题",
+            "titleChange-help": "当房间标题变化时触发，占位符{oldTitle}:旧标题(string) {newTitle}:新标题(string)",
             "titleChange": [],
-            "afterRec-help": "当结束录制后(包含切片)触发对应的命令，recSec:录制时长超过指定秒数才触发，占位符{liveDir}:录播所在目录 {recSec}:录制时长秒数(uint)(>=0) {type}:视频类型",
-            "afterRec":["ffmpeg","-i","{liveDir}0.{type}","-y","-c","copy","{liveDir}1.{type}"]
+            "afterRec-help": "当结束录制后(包含切片)触发对应的命令，占位符{liveDir}:录播所在目录(string)(末尾有/) {recSec}:录制时长秒数(uint)(>=0) {type}:视频类型(string)(例如mp4)",
+            "afterRec":[]
         }
     ],
     "指定房间录制区间-help":"指定roomid的房间在指定时间段内将会开启录制.start时检查是否在直播,是则开始录制,如已在录制则切片.end时停止录制.在开播时,若同时有start与end的fromTo,且当前在start与end之间,则录制,若无同时有start与end,则开播就录制。5s内只能触发一个fromTo",


### PR DESCRIPTION
#### 指定房间回调
在(>v0.20.19)，添加了`指定房间回调`配置项。

其扩展了原配置项`指定房间录制回调`，`指定房间录制回调`将失效。

```json
{
  "指定房间回调":[
    {
      "roomid-help": "指定房间号，0时禁用",
      "roomid":0,
      "runDir-help": "命令执行目录，为空时为本程序所在目录",
      "runDir": "",
      "begin-help": "当开播时触发命令",
      "begin": [],
      "fin-help": "当下播时触发命令",
      "fin": [],
      "titleChange-help": "当房间标题变化时触发，占位符{oldTitle}:旧标题(string) {newTitle}:新标题(string)",
      "titleChange": [],
      "afterRec-help": "当结束录制后(包含切片)触发对应的命令，占位符{liveDir}:录播所在目录(string)(末尾有/) {recSec}:录制时长秒数(uint)(>=0) {type}:视频类型(string)(例如mp4)",
      "afterRec":[]
    }
  ]
}
```

从`指定房间录制回调`升级，此处使用linux示例：
```json
{
  "durationS":60,
  "after":["ffmpeg","-i","0.{type}","-y","-c","copy","1.{type}"]
}
```
->
```json
{
  "runDir": "/xxxx/",
  "afterRec":["./a.sh", "{liveDir}", "{recSec}", "{type}"]
}
```
```sh
/xxxx/a.sh
#!/bin/bash
if [ "$2" -gt 60 ]; then
  cd $1
  ffmpeg -i 0.$3 -y -c copy 1.$3
fi
```