### PR TITLE
Fix data race

### DIFF
--- a/CV/Var.go
+++ b/CV/Var.go
@@ -108,6 +108,11 @@ func (t *Common) Lock() func() {
 	return t.l.Unlock
 }
 
+func (t *Common) RLock() func() {
+	t.l.RLock()
+	return t.l.Unlock
+}
+
 func (t *Common) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Live          []*LiveQn `json:"live"`

--- a/F/api_v2.go
+++ b/F/api_v2.go
@@ -93,8 +93,8 @@ func (t *GetFuncV2) isValid(key string) func() bool {
 			return t.common.ParentAreaID > 0
 		case `AreaID`:
 			return t.common.AreaID > 0
-		case `GuardNum`:
-			return t.common.GuardNum > 0
+		// case `GuardNum`:
+		// 	return t.common.GuardNum > 0
 		case `Note`:
 			return t.common.Note != ``
 		case `Live_qn`:

--- a/Reply/Reply.go
+++ b/Reply/Reply.go
@@ -700,7 +700,7 @@ func (t replyF) room_change(s []byte) {
 		msglog.BaseAdd("房").I(sh...)
 
 		go replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
-			if e := inter.FiliterRoomId(t.K_v.LoadV("指定房间回调"), t.Roomid).TitleChange(oldTitle, t.Title); e != nil {
+			if e := inter.FiliterRoomId(t.K_v.LoadV("指定房间回调"), t.Roomid).TitleChange(oldTitle, type_item.Data.Title); e != nil {
 				msglog.BaseAdd("房").W(e)
 			}
 		})
@@ -715,25 +715,42 @@ func (t replyF) room_change(s []byte) {
 		ctx, cancle := context.WithTimeout(context.Background(), time.Second*time.Duration(tryS))
 		roomChangeFC.FlashWithCallback(cancle)
 
-		go func(ctx context.Context, roomid int) {
-			for t.Roomid == roomid {
+		go func(ctx context.Context, roomid int, title string) {
+			var (
+				loopRoomId = roomid
+				loopTitle  = title
+			)
+			for loopRoomId == roomid {
 				select {
 				case <-ctx.Done():
 					msglog.BaseAdd("房").W(`指定时长内标题未修改，可能需要调大标题修改检测s`)
 					return
 				case <-time.After(time.Second * 30):
-					if beforeTitle := t.Title; t.Roomid != roomid || beforeTitle != oldTitle {
+					{
+						ulock := t.RLock()
+						loopRoomId = t.Roomid
+						loopTitle = t.Title
+						ulock()
+					}
+					// 切换房间 or 循环外标题改变
+					if loopRoomId != roomid || loopTitle != title {
 						return
 					} else {
 						F.Api.Get(t.Common, `Title`)
-						if t.Roomid == roomid && t.Title != beforeTitle {
-							setTitle(t.Title)
-							var sh = []any{"标题改变", t.Title}
+						{
+							ulock := t.RLock()
+							loopRoomId = t.Roomid
+							loopTitle = t.Title
+							ulock()
+						}
+						if loopRoomId == roomid && loopTitle != title {
+							setTitle(loopTitle)
+							var sh = []any{"标题改变", loopTitle}
 							Gui_show(Itos(sh), "0room")
 							msglog.BaseAdd("房").I(sh...)
 
 							go replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
-								if e := inter.FiliterRoomId(t.K_v.LoadV("指定房间回调"), t.Roomid).TitleChange(beforeTitle, t.Title); e != nil {
+								if e := inter.FiliterRoomId(t.K_v.LoadV("指定房间回调"), loopRoomId).TitleChange(title, loopTitle); e != nil {
 									msglog.BaseAdd("房").W(e)
 								}
 							})
@@ -743,7 +760,7 @@ func (t replyF) room_change(s []byte) {
 					}
 				}
 			}
-		}(ctx, t.Roomid)
+		}(ctx, t.Roomid, t.Title)
 	}
 }
 

--- a/Reply/Reply.go
+++ b/Reply/Reply.go
@@ -1016,7 +1016,7 @@ func (t replyF) live(s []byte) {
 	if err := json.Unmarshal(s, &type_item); err != nil {
 		msglog.E(err)
 		return
-	} else {
+	} else if !t.Liveing {
 		{ //附加功能 obs录播
 			// Obsf(true)
 			// Obs_R(true)

--- a/bili_danmu.go
+++ b/bili_danmu.go
@@ -383,10 +383,9 @@ func entryRoom(mainCtx context.Context, danmulog *plog.Log, common *c.Common) (e
 		danmulog.T("连接 " + v)
 		u, _ := url.Parse(v)
 		ws_c, err := ws.NewClient(&ws.Client{
-			// BufSize:           150,
 			Url:               v,
-			RTOMs:             (heartinterval + 5) * 1000,
-			WTOMs:             (heartinterval + 5) * 1000,
+			RTO:               time.Duration((heartinterval + 5) * int(time.Second)),
+			WTO:               time.Duration((heartinterval + 5) * int(time.Second)),
 			Proxy:             common.Proxy,
 			Func_abort_close:  func() { danmulog.I(`服务器连接中断`) },
 			Func_normal_close: func() { danmulog.I(`服务器连接关闭`) },
@@ -603,7 +602,7 @@ func entryRoom(mainCtx context.Context, danmulog *plog.Log, common *c.Common) (e
 			}
 
 			if err := ws_c.Error(); err != nil {
-				danmulog.E("结束连接错误", err)
+				danmulog.W("结束连接错误", err)
 			}
 
 			cancelfunc()

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/mdp/qrterminal/v3 v3.2.0
-	github.com/qydysky/part v0.28.20260612191428
+	github.com/qydysky/part v0.28.20260613083913
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/text v0.31.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/mdp/qrterminal/v3 v3.2.0
-	github.com/qydysky/part v0.28.20260510134627
+	github.com/qydysky/part v0.28.20260612191428
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/text v0.31.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/qydysky/biliApi v0.0.0-20260226134054-aeb783162dab h1:/QYhfxCo1Quu9QM
 github.com/qydysky/biliApi v0.0.0-20260226134054-aeb783162dab/go.mod h1:AFTXs+mq7iF7TIPhsx6MR3UMbUIQJMCoKpemTxqZmTg=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a h1:OSIFTKGKsOLYycboWvW/1EvgPMinwtm2/IH+TE/zYrc=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a/go.mod h1:cI8/gy/wjy2Eb+p2IUj2ZuDnC8R5Vrx3O0VMPvMvphA=
-github.com/qydysky/part v0.28.20260510134627 h1:Em37K7XYz0z5knXqYE3UK8jQLKGv/l64k2pQGXv2zJQ=
-github.com/qydysky/part v0.28.20260510134627/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
+github.com/qydysky/part v0.28.20260612191428 h1:UAXjHaPRf/j4PZfKcQ+FqtQ/an61jbED7Vj3wPLtacg=
+github.com/qydysky/part v0.28.20260612191428/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/qydysky/biliApi v0.0.0-20260226134054-aeb783162dab h1:/QYhfxCo1Quu9QM
 github.com/qydysky/biliApi v0.0.0-20260226134054-aeb783162dab/go.mod h1:AFTXs+mq7iF7TIPhsx6MR3UMbUIQJMCoKpemTxqZmTg=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a h1:OSIFTKGKsOLYycboWvW/1EvgPMinwtm2/IH+TE/zYrc=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a/go.mod h1:cI8/gy/wjy2Eb+p2IUj2ZuDnC8R5Vrx3O0VMPvMvphA=
-github.com/qydysky/part v0.28.20260612191428 h1:UAXjHaPRf/j4PZfKcQ+FqtQ/an61jbED7Vj3wPLtacg=
-github.com/qydysky/part v0.28.20260612191428/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
+github.com/qydysky/part v0.28.20260613083913 h1:W4V9Glg1RmrS2bALwbVM5HhT6bi7lWd1d/uk3xXoC1w=
+github.com/qydysky/part v0.28.20260613083913/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=


### PR DESCRIPTION
```log

WARNING: DATA RACE
Write at 0x00c000268070 by goroutine 116:
  github.com/qydysky/bili_danmu/F.(*GetFuncV2).getRoomBaseInfo()
      /home/runner/work/bili_danmu/bili_danmu/F/api_v2.go:422 +0x6aa
  github.com/qydysky/bili_danmu/F.(*GetFuncV2).getRoomBaseInfo-fm()
      <autogenerated>:1 +0x2e
  github.com/qydysky/part/keyFunc.(*KeyFunc).getTrace()
      /home/runner/work/bili_danmu/bili_danmu/vendor/github.com/qydysky/part/keyFunc/keyFunc.go:141 +0x5f4
  github.com/qydysky/part/keyFunc.(*KeyFunc).GetTrace()
      /home/runner/work/bili_danmu/bili_danmu/vendor/github.com/qydysky/part/keyFunc/keyFunc.go:125 +0x1d3
  github.com/qydysky/bili_danmu/F.(*GetFuncV2).Get()
      /home/runner/work/bili_danmu/bili_danmu/F/api_v2.go:74 +0x1a8
  github.com/qydysky/bili_danmu/Reply.(*M4SStream).Start()
      /home/runner/work/bili_danmu/bili_danmu/Reply/stream.go:1404 +0x130
  github.com/qydysky/bili_danmu/Reply.StreamOStart()
      /home/runner/work/bili_danmu/bili_danmu/Reply/F.go:104 +0x366
  github.com/qydysky/bili_danmu/Reply.replyF.live.func1()
      /home/runner/work/bili_danmu/bili_danmu/Reply/Reply.go:1019 +0x2c4

Previous read at 0x00c000268070 by goroutine 107:
  github.com/qydysky/bili_danmu/Reply.replyF.room_change.func1()
      /home/runner/work/bili_danmu/bili_danmu/Reply/Reply.go:703 +0xef
  github.com/qydysky/part/component2.(*GetRunner[go.shape.interface { FiliterRoomId(interface {}, int) interface { AfterRec(string, string, time.Duration) error; Begin() error; Fin() error; LoginChange(bool) error; TitleChange(string, string) error } }]).Run2()
      /home/runner/work/bili_danmu/bili_danmu/vendor/github.com/qydysky/part/component2/comp.go:166 +0x65
  github.com/qydysky/bili_danmu/Reply.replyF.room_change.gowrap1()
      /home/runner/work/bili_danmu/bili_danmu/Reply/Reply.go:702 +0xe
```