### PR TITLE
Improve 优化重新登陆行为

### DIFF
--- a/CV/Var.go
+++ b/CV/Var.go
@@ -246,7 +246,7 @@ var ActQnMatch = pe.Action[struct {
 }](`ActQnMatch`)
 
 func (t *Common) QnMatched() error {
-	if !t.Login {
+	if !t.IsLogin() {
 		return ActQnMatch.NoLogin
 	} else if t.Live_want_qn != t.Live_qn {
 		return ActQnMatch.NoMatched

--- a/CV/Var.go
+++ b/CV/Var.go
@@ -146,7 +146,7 @@ func (t *Common) MarshalJSON() ([]byte, error) {
 		ParentAreaID:  t.ParentAreaID,
 		AreaID:        t.AreaID,
 		Locked:        t.Locked,
-		Login:         t.Login,
+		Login:         t.IsLogin(),
 		Note:          t.Note,
 		LiveStartTime: t.Live_Start_Time.Format(time.RFC3339),
 		Liveing:       t.Liveing,

--- a/F/api_v2.go
+++ b/F/api_v2.go
@@ -14,6 +14,7 @@ import (
 	c "github.com/qydysky/bili_danmu/CV"
 	pe "github.com/qydysky/part/errors/v2"
 	file "github.com/qydysky/part/file"
+	fc "github.com/qydysky/part/funcCtrl"
 	pkf "github.com/qydysky/part/keyFunc"
 	reqf "github.com/qydysky/part/reqf"
 	unsafe "github.com/qydysky/part/unsafe"
@@ -37,6 +38,8 @@ type GetFuncV2 struct {
 func NewGetFuncV2() *GetFuncV2 {
 	t := &GetFuncV2{api: pkf.NewKeyFunc()}
 	t.api.Reg(`CookieNoBlock`, t.isValid(`Cookie`), t.getCookieNoBlock)
+	t.api.Reg(`Logout`, func() bool { return true }, t.logout)
+	t.api.Reg(`LoginCheck`, func() bool { return true }, t.loginCheck)
 	t.api.Reg(`Cookie`, t.isValid(`Cookie`), t.getCookie)
 	t.api.Reg(`UpUid`, t.isValid(`UpUid`), t.getRoomBaseInfo, t.getInfoByRoom, t.getRoomPlayInfoLive, t.htmlLive)
 	t.api.Reg(`Live_Start_Time`, t.isValid(`Live_Start_Time`), t.getRoomBaseInfo, t.getInfoByRoom, t.getRoomPlayInfoLive, t.htmlLive)
@@ -114,9 +117,49 @@ func (t *GetFuncV2) isValid(key string) func() bool {
 	}
 }
 
+func (t *GetFuncV2) logout() (missKey string, err error) {
+	biliApi := biliApi.Inter(func(ce error) BiliApiInter {
+		err = ce
+		apilog.E(`biliApi组件未构建`, ce)
+		return nil
+	})
+	if biliApi == nil {
+		return
+	}
+	if err = biliApi.Logout(); err != nil {
+		apilog.E(err)
+	} else if err = biliApi.GetOtherCookies(); err != nil {
+		apilog.E(err)
+	}
+	return
+}
+
+func (t *GetFuncV2) loginCheck() (missKey string, err error) {
+	biliApi := biliApi.Inter(func(ce error) BiliApiInter {
+		err = ce
+		apilog.E(`biliApi组件未构建`, ce)
+		return nil
+	})
+	if biliApi == nil {
+		return
+	}
+	if err, _ := biliApi.GetNav(); err != nil {
+		apilog.E(err)
+	}
+	return
+}
+
+var loginRunning fc.SkipFunc
+
 // 扫码登录
 func (t *GetFuncV2) getCookie() (missKey string, err error) {
 	apilog := apilog.BaseAdd(`获取Cookie`)
+
+	if loginRunning.NeedSkip() {
+		apilog.T(`登陆中Skip`)
+		return
+	}
+	defer loginRunning.UnSet()
 
 	savepath := "./cookie.txt"
 	if tmp, ok := t.common.K_v.LoadV("cookie路径").(string); ok && tmp != "" {
@@ -200,29 +243,43 @@ func (t *GetFuncV2) getCookie() (missKey string, err error) {
 		defer func() {
 			_ = os.RemoveAll(`qr.png`)
 		}()
-		//启动web
-		if scanPath, ok := t.common.K_v.LoadV("扫码登录路径").(string); ok && scanPath != "" {
-			if t.common.K_v.LoadV(`扫码登录自动打开标签页`).(bool) {
-				_ = open.Run(`http://127.0.0.1:` + t.common.Stream_url.Port() + scanPath)
+		scanPath, _ := t.common.K_v.LoadV("扫码登录路径").(string)
+		noShowInCmd, _ := t.common.K_v.LoadV("扫码登录-命令行不显示二维码").(bool)
+		{
+			//启动web
+			if scanPath != "" {
+				if t.common.K_v.LoadV(`扫码登录自动打开标签页`).(bool) {
+					_ = open.Run(`http://127.0.0.1:` + t.common.Stream_url.Port() + scanPath)
+				}
 			}
-			apilog.W(`扫描命令行二维码或打开链接扫码登录：` + t.common.Stream_url.String() + scanPath)
+			info := ``
+			if !noShowInCmd {
+				info += `扫描命令行二维码 `
+			}
+			if scanPath != "" {
+				info += `打开链接扫码 `
+			}
+			info += `登录：`
+			apilog.W(info + t.common.Stream_url.String() + scanPath)
 		}
 
-		c := qrterminal.Config{
-			Level:     qrterminal.L,
-			Writer:    os.Stdout,
-			BlackChar: `  `,
-			WhiteChar: `OO`,
+		if !noShowInCmd {
+			c := qrterminal.Config{
+				Level:     qrterminal.L,
+				Writer:    os.Stdout,
+				BlackChar: `  `,
+				WhiteChar: `OO`,
+			}
+			if white, ok := t.common.K_v.LoadV(`登录二维码-白`).(string); ok && len(white) != 0 {
+				c.WhiteChar = white
+			}
+			if black, ok := t.common.K_v.LoadV(`登录二维码-黑`).(string); ok && len(black) != 0 {
+				c.BlackChar = black
+			}
+			//show qr code in cmd
+			qrterminal.GenerateWithConfig(img_url, c)
 		}
-		if white, ok := t.common.K_v.LoadV(`登录二维码-白`).(string); ok && len(white) != 0 {
-			c.WhiteChar = white
-		}
-		if black, ok := t.common.K_v.LoadV(`登录二维码-黑`).(string); ok && len(black) != 0 {
-			c.BlackChar = black
-		}
-		//show qr code in cmd
-		qrterminal.GenerateWithConfig(img_url, c)
-		apilog.I(`手机扫命令行二维码登录。如不登录，修改配置文件"扫码登录"为false`)
+		apilog.I(`如不登录，修改配置文件"扫码登录"为false`)
 		time.Sleep(time.Second)
 	}
 
@@ -265,6 +322,11 @@ func (t *GetFuncV2) getCookie() (missKey string, err error) {
 
 func (t *GetFuncV2) getCookieNoBlock() (missKey string, err error) {
 	apilog := apilog.BaseAdd(`获取Cookie`)
+
+	if loginRunning.NeedSkip() {
+		apilog.T(`登陆中Skip`)
+		return
+	}
 
 	savepath := "./cookie.txt"
 	if tmp, ok := t.common.K_v.LoadV("cookie路径").(string); ok && tmp != "" {
@@ -329,33 +391,53 @@ func (t *GetFuncV2) getCookieNoBlock() (missKey string, err error) {
 			apilog.E(`qr error`)
 			return
 		}
-		//启动web
-		if scanPath, ok := t.common.K_v.LoadV("扫码登录路径").(string); ok && scanPath != "" {
-			if t.common.K_v.LoadV(`扫码登录自动打开标签页`).(bool) {
-				_ = open.Run(`http://127.0.0.1:` + t.common.Stream_url.Port() + scanPath)
+		scanPath, _ := t.common.K_v.LoadV("扫码登录路径").(string)
+		noShowInCmd, _ := t.common.K_v.LoadV("扫码登录-命令行不显示二维码").(bool)
+		{
+			//启动web
+			if scanPath != "" {
+				if t.common.K_v.LoadV(`扫码登录自动打开标签页`).(bool) {
+					_ = open.Run(`http://127.0.0.1:` + t.common.Stream_url.Port() + scanPath)
+				}
 			}
-			apilog.W(`扫描命令行二维码或打开链接扫码登录：` + t.common.Stream_url.String() + scanPath)
+			info := ``
+			if !noShowInCmd {
+				info += `扫描命令行二维码 `
+			}
+			if scanPath != "" {
+				info += `打开链接扫码 `
+			}
+			info += `登录：`
+			apilog.W(info + t.common.Stream_url.String() + scanPath)
 		}
 
-		c := qrterminal.Config{
-			Level:     qrterminal.L,
-			Writer:    os.Stdout,
-			BlackChar: `  `,
-			WhiteChar: `OO`,
+		if !noShowInCmd {
+			c := qrterminal.Config{
+				Level:     qrterminal.L,
+				Writer:    os.Stdout,
+				BlackChar: `  `,
+				WhiteChar: `OO`,
+			}
+			if white, ok := t.common.K_v.LoadV(`登录二维码-白`).(string); ok && len(white) != 0 {
+				c.WhiteChar = white
+			}
+			if black, ok := t.common.K_v.LoadV(`登录二维码-黑`).(string); ok && len(black) != 0 {
+				c.BlackChar = black
+			}
+			//show qr code in cmd
+			qrterminal.GenerateWithConfig(img_url, c)
 		}
-		if white, ok := t.common.K_v.LoadV(`登录二维码-白`).(string); ok && len(white) != 0 {
-			c.WhiteChar = white
-		}
-		if black, ok := t.common.K_v.LoadV(`登录二维码-黑`).(string); ok && len(black) != 0 {
-			c.BlackChar = black
-		}
-		//show qr code in cmd
-		qrterminal.GenerateWithConfig(img_url, c)
-		apilog.I(`手机扫命令行二维码登录。如不登录，修改配置文件"扫码登录"为false`)
+		apilog.I(`如不登录，修改配置文件"扫码登录"为false`)
+		time.Sleep(time.Second)
+	}
+
+	if err := biliApi.GetOtherCookies(); err != nil {
+		apilog.E(err)
 	}
 
 	{ //循环查看是否通过
 		go func() {
+			defer loginRunning.UnSet()
 			//获取其他Cookie
 			defer func() {
 				if err := biliApi.GetOtherCookies(); err != nil {

--- a/F/biliApiInterface.go
+++ b/F/biliApiInterface.go
@@ -12,12 +12,12 @@ type BiliApiInter interface {
 	SetReqPool(pool *pool.Buf[reqf.Req])
 	SetProxy(proxy string)
 	SetDisableSystemProxy(disableSystemProxy bool)
-	SetLocation(secOfTimeZone int)                   // east positive
-	SetCookies(cookies []*http.Cookie)               // 设置bili cookie，用于从cookie持久化中恢复
-	SetCookiesCallback(func(cookies []*http.Cookie)) // 当有新cookie时，将调用，用于cookie持久化
-	GetCookies() (cookies []*http.Cookie)            // 获取所有cookie，用于其他需要cookie的情况
-	GetCookie(name string) (error, string)           // 获取特定cookie，用于其他需要cookie的情况
-	IsLogin() bool                                   // 通过cookie判断是否登录
+	SetLocation(secOfTimeZone int)                        // east positive
+	SetCookies(cookies []*http.Cookie, overwrite ...bool) // 设置bili cookie，用于从cookie持久化中恢复
+	SetCookiesCallback(func(cookies []*http.Cookie))      // 当有新cookie时，将调用，用于cookie持久化
+	GetCookies() (cookies []*http.Cookie)                 // 获取所有cookie，用于其他需要cookie的情况
+	GetCookie(name string) (error, string)                // 获取特定cookie，用于其他需要cookie的情况
+	IsLogin() bool                                        // 通过cookie判断是否登录
 
 	LikeReport(hitCount, uid, roomid, upUid int) (err error)
 	LoginQrCode() (err error, imgUrl string, QrcodeKey string)

--- a/F/biliApiInterface.go
+++ b/F/biliApiInterface.go
@@ -22,6 +22,7 @@ type BiliApiInter interface {
 	LikeReport(hitCount, uid, roomid, upUid int) (err error)
 	LoginQrCode() (err error, imgUrl string, QrcodeKey string)
 	LoginQrPoll(QrcodeKey string) (err error, code int)
+	Logout() error
 	GetOtherCookies() (err error)
 	GetLiveBuvid(Roomid int) (err error)
 	GetRoomBaseInfo(Roomid int) (err error, res struct {

--- a/F/comp.go
+++ b/F/comp.go
@@ -24,7 +24,8 @@ var biliApi = cmp.GetV3("github.com/qydysky/bili_danmu/F.biliApi", cmp.PreFuncCu
 		}
 		ba.SetCookiesCallback(func(cookies []*http.Cookie) {
 			CookieSet(savepath, unsafe.S2B(reqf.Cookies_List_2_String(cookies))) //cookie 存入文件
-			psync.StoreAll(c.C.Cookie, reqf.Cookies_List_2_Map(cookies))         //cookie 存入全局变量
+			c.C.Cookie.ClearAll()
+			psync.StoreAll(c.C.Cookie, reqf.Cookies_List_2_Map(cookies)) //cookie 存入全局变量
 		})
 		return ba
 	},

--- a/F/comp.go
+++ b/F/comp.go
@@ -2,6 +2,7 @@ package F
 
 import (
 	"net/http"
+	"sync/atomic"
 
 	_ "github.com/qydysky/biliApi" //removable
 	c "github.com/qydysky/bili_danmu/CV"
@@ -22,10 +23,14 @@ var biliApi = cmp.GetV3("github.com/qydysky/bili_danmu/F.biliApi", cmp.PreFuncCu
 		if tmp, ok := c.C.K_v.LoadV("cookie路径").(string); ok && tmp != "" {
 			savepath = tmp
 		}
+		var loginState atomic.Bool
 		ba.SetCookiesCallback(func(cookies []*http.Cookie) {
 			CookieSet(savepath, unsafe.S2B(reqf.Cookies_List_2_String(cookies))) //cookie 存入文件
 			c.C.Cookie.ClearAll()
 			psync.StoreAll(c.C.Cookie, reqf.Cookies_List_2_Map(cookies)) //cookie 存入全局变量
+			if cuState := c.C.IsLogin(); loginState.Swap(cuState) != cuState {
+				go c.C.Danmu_Main_mq.Push_tag(`changeLogin`, nil)
+			}
 		})
 		return ba
 	},

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@
 #### 指定房间回调
 在(>v0.20.19)，添加了`指定房间回调`配置项。
 
+在(>v0.21.5)，`指定房间回调`配置项添加了`loginChange`,当登陆状态变化时触发对应的命令。
+
 其扩展了原配置项`指定房间录制回调`，`指定房间录制回调`将失效。
 
 ```json
@@ -99,7 +101,9 @@
       "titleChange-help": "当房间标题变化时触发，占位符{oldTitle}:旧标题(string) {newTitle}:新标题(string)",
       "titleChange": [],
       "afterRec-help": "当结束录制后(包含切片)触发对应的命令，占位符{liveDir}:录播所在目录(string)(末尾有/) {recSec}:录制时长秒数(uint)(>=0) {type}:视频类型(string)(例如mp4)",
-      "afterRec":[]
+      "afterRec":[],
+      "loginChange-help": "当登陆状态变化时触发对应的命令，占位符{newState}:新的状态(string)(true/false)",
+      "loginChange":[]
     }
   ]
 }
@@ -1027,6 +1031,8 @@ Ass默认`utf-8`编码，在录播结束时生成，可以配合`指定房间回
   - [MXPlayer](https://sites.google.com/site/mxvpen/home)
 
 #### 命令行操作
+在(>v0.21.5)在登陆状态时可以使用` logout`登出当前cookie。
+
 在准备动作完成(`T: 2021/03/06 16:22:39 命令行操作 [回车查看帮助]`)后，输入回车将显示帮助
 ```
 切换房间->输入' 数字'回车

--- a/Reply/F/roomSignal/roomSignal.go
+++ b/Reply/F/roomSignal/roomSignal.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	comp "github.com/qydysky/part/component2"
@@ -55,18 +54,18 @@ func (t impl) FiliterRoomId(configs any, roomId int) interface {
 }
 
 var (
-	loginStateInit atomic.Bool
-	lastLoginState atomic.Bool
-	loginRunning   fc.SkipFunc
+	// loginStateInit atomic.Bool
+	// lastLoginState atomic.Bool
+	loginRunning fc.SkipFunc
 )
 
 func (t *impl) LoginChange(isLogin bool) error {
-	if loginStateInit.CompareAndSwap(false, true) {
-		lastLoginState.Store(isLogin)
-		return nil
-	} else if lastLoginState.Swap(isLogin) == isLogin {
-		return nil
-	}
+	// if loginStateInit.CompareAndSwap(false, true) {
+	// 	lastLoginState.Store(isLogin)
+	// 	return nil
+	// } else if lastLoginState.Swap(isLogin) == isLogin {
+	// 	return nil
+	// }
 	defer loginRunning.UnSet()
 	if loginRunning.NeedSkip() {
 		return nil
@@ -79,9 +78,18 @@ func (t *impl) LoginChange(isLogin bool) error {
 	if len(loginChange) < 1 {
 		return nil
 	}
-	var cmds []string
+	var (
+		cmds     []string
+		newState string
+	)
+	if isLogin {
+		newState = "true"
+	} else {
+		newState = "false"
+	}
 	for i := 0; i < len(loginChange); i++ {
 		if cmd, ok := loginChange[i].(string); ok && cmd != "" {
+			cmd = strings.ReplaceAll(cmd, `{newState}`, newState)
 			cmds = append(cmds, cmd)
 		}
 	}

--- a/bili_danmu.go
+++ b/bili_danmu.go
@@ -335,8 +335,8 @@ func entryRoom(mainCtx context.Context, danmulog *plog.Log, common *c.Common) (e
 					cancel1()
 					continue
 				}
-				//获取cookie，检查是否登录失效
-				F.Api.Get(common, `Cookie`)
+				//检查是否登录失效
+				F.Api.Get(common, `LoginCheck`)
 				//获取LIVE_BUVID
 				// F.Api.Get(common, `LIVE_BUVID`)
 				//附加功能 自动发送即将过期礼物
@@ -427,7 +427,6 @@ func entryRoom(mainCtx context.Context, danmulog *plog.Log, common *c.Common) (e
 			}
 			continue
 		}
-
 		// auth
 		{
 			wsmsg.PushLock_tag(`send`, &ws.WsMsg{
@@ -448,7 +447,10 @@ func entryRoom(mainCtx context.Context, danmulog *plog.Log, common *c.Common) (e
 			<-waitCheckAuth.Done()
 			doneAuth()
 			if err := waitCheckAuth.Err(); errors.Is(err, context.DeadlineExceeded) {
-				danmulog.E("连接验证失败")
+				danmulog.E("连接验证超时")
+				// if ws_c.Isclose() {
+				// 	loopCancel()
+				// }
 				continue
 			}
 		}
@@ -545,7 +547,7 @@ func entryRoom(mainCtx context.Context, danmulog *plog.Log, common *c.Common) (e
 
 		//当前ws
 		{
-			var login = common.Login
+			// var login = common.Login
 			// 处理各种指令
 			var cancelfunc = common.Danmu_Main_mq.Pull_tag(msgq.FuncMap{
 				`interrupt`: func(_ any) (disable bool) {
@@ -582,11 +584,23 @@ func entryRoom(mainCtx context.Context, danmulog *plog.Log, common *c.Common) (e
 					go F.Api.Get(common, `GuardNum`)
 					return false
 				},
+				`changeLogin`: func(_ any) bool { //登陆状态更新
+					// F.Api.Get(common, `Cookie`)
+					cuState, roomid := common.IsLogin(), common.Roomid
+					go replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
+						if e := inter.FiliterRoomId(c.C.K_v.LoadV(`指定房间回调`), roomid).LoginChange(cuState); e != nil {
+							c.C.Log.Base(`指定房间回调`).W(roomid, e)
+						}
+					})
+					// if login != cuState {
+					danmulog.T("登陆状态变化，重新进入直播间", common.Uname, `(`, common.Roomid, `)`)
+					// common.Danmu_Main_mq.Push_tag(`flash_room`, nil)
+					loopCancel()
+					ws_c.Close()
+					// }
+					return true
+				},
 				`every100s`: func(_ any) bool { //每100s
-					if login != c.C.IsLogin() {
-						common.Danmu_Main_mq.Push_tag(`flash_room`, nil)
-						return false
-					}
 					if v, ok := common.K_v.LoadV("保持牌子亮着-开播时也发送").(bool); !common.Liveing || (ok && v) {
 						replyFunc.KeepMedalLight.Run2(func(kmli replyFunc.KeepMedalLightI) {
 							kmli.Do()

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -40,6 +40,7 @@ func (t *cmd) Cmd() {
 					if _, ok := c.C.Cookie.LoadV(`bili_jct`).(string); ok {
 						fmt.Println("查看直播中主播->输入' liv'回车")
 						fmt.Println("查看历史观看主播->输入' his'回车")
+						fmt.Println("登出->输入' logout'回车")
 					} else {
 						fmt.Println("登录->输入' login'回车")
 					}
@@ -51,6 +52,7 @@ func (t *cmd) Cmd() {
 				if _, ok := c.C.Cookie.LoadV(`bili_jct`).(string); ok {
 					fmt.Println("发送弹幕->输入'字符串'回车")
 					fmt.Println("查看直播中主播->输入' liv'回车")
+					fmt.Println("登出->输入' logout'回车")
 				} else {
 					fmt.Println("登录->输入' login'回车")
 				}
@@ -159,6 +161,12 @@ func (t *cmd) Cmd() {
 				if strings.Contains(inputs, ` login`) {
 					//获取cookie
 					F.Api.Get(c.C, `Cookie`)
+					continue
+				}
+				//登出
+				if strings.Contains(inputs, ` logout`) {
+					//获取cookie
+					F.Api.Get(c.C, `Logout`)
 					continue
 				}
 				//搜索主播

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/mdp/qrterminal/v3 v3.2.0
-	github.com/qydysky/part v0.28.20260719082343
+	github.com/qydysky/part v0.28.20260722164949
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/text v0.37.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/mdp/qrterminal/v3 v3.2.0
-	github.com/qydysky/part v0.28.20260722164949
+	github.com/qydysky/part v0.28.20260722185429
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	golang.org/x/text v0.37.0 // indirect
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/qydysky/biliApi v0.0.0-20260614123854-6f721592e381
+	github.com/qydysky/biliApi v0.0.0-20260722190153-5323575bf2e1
 	github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/qydysky/biliApi v0.0.0-20260722190153-5323575bf2e1
+	github.com/qydysky/biliApi v0.0.0-20260726175122-c4a976b61578
 	github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a
 	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6
 )

--- a/go.sum
+++ b/go.sum
@@ -42,12 +42,12 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/qydysky/biliApi v0.0.0-20260614123854-6f721592e381 h1:X4k3Cd9oPNbGoU5TEsHADuZSj8HHyMxOkNMGFW7VwBs=
-github.com/qydysky/biliApi v0.0.0-20260614123854-6f721592e381/go.mod h1:8b6eobq6gSt2Y3ulDBcRCSA5KIDM0dmts9Qz9vxZi5k=
+github.com/qydysky/biliApi v0.0.0-20260722190153-5323575bf2e1 h1:ctnyD1sw96osObPLBn6i8gh8rAA3aBmCJ55n9SjTBrs=
+github.com/qydysky/biliApi v0.0.0-20260722190153-5323575bf2e1/go.mod h1:eMecpH5obl1Ek6lOQnkjh+pk8UqlOFueW335XGz1eiw=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a h1:OSIFTKGKsOLYycboWvW/1EvgPMinwtm2/IH+TE/zYrc=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a/go.mod h1:cI8/gy/wjy2Eb+p2IUj2ZuDnC8R5Vrx3O0VMPvMvphA=
-github.com/qydysky/part v0.28.20260722164949 h1:4v3aIYCvGsprMNFCRwY2wHsn3Juu8esE8+zywX8RxgY=
-github.com/qydysky/part v0.28.20260722164949/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
+github.com/qydysky/part v0.28.20260722185429 h1:j17wtrvwvPueqjHL+iJH3mSETueM/XiGgL3hVTsxc20=
+github.com/qydysky/part v0.28.20260722185429/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/qydysky/biliApi v0.0.0-20260614123854-6f721592e381 h1:X4k3Cd9oPNbGoU5
 github.com/qydysky/biliApi v0.0.0-20260614123854-6f721592e381/go.mod h1:8b6eobq6gSt2Y3ulDBcRCSA5KIDM0dmts9Qz9vxZi5k=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a h1:OSIFTKGKsOLYycboWvW/1EvgPMinwtm2/IH+TE/zYrc=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a/go.mod h1:cI8/gy/wjy2Eb+p2IUj2ZuDnC8R5Vrx3O0VMPvMvphA=
-github.com/qydysky/part v0.28.20260719082343 h1:E/9VnBt7pBIZDqGeCs20jMhoFU3rg7gE1249vgAk4Os=
-github.com/qydysky/part v0.28.20260719082343/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
+github.com/qydysky/part v0.28.20260722164949 h1:4v3aIYCvGsprMNFCRwY2wHsn3Juu8esE8+zywX8RxgY=
+github.com/qydysky/part v0.28.20260722164949/go.mod h1:yG6c1GmRQ/ksaCbNpPlRqztHrjJBCBBovvrj380eMsk=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/qydysky/biliApi v0.0.0-20260722190153-5323575bf2e1 h1:ctnyD1sw96osObPLBn6i8gh8rAA3aBmCJ55n9SjTBrs=
-github.com/qydysky/biliApi v0.0.0-20260722190153-5323575bf2e1/go.mod h1:eMecpH5obl1Ek6lOQnkjh+pk8UqlOFueW335XGz1eiw=
+github.com/qydysky/biliApi v0.0.0-20260726175122-c4a976b61578 h1:Y9oQMiJ/+hmOGCWDHpAJj78XtxBj/gc0ngU5CbaTcHA=
+github.com/qydysky/biliApi v0.0.0-20260726175122-c4a976b61578/go.mod h1:eMecpH5obl1Ek6lOQnkjh+pk8UqlOFueW335XGz1eiw=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a h1:OSIFTKGKsOLYycboWvW/1EvgPMinwtm2/IH+TE/zYrc=
 github.com/qydysky/brotli v0.0.0-20250531004300-54adcf96cc4a/go.mod h1:cI8/gy/wjy2Eb+p2IUj2ZuDnC8R5Vrx3O0VMPvMvphA=
 github.com/qydysky/part v0.28.20260722185429 h1:j17wtrvwvPueqjHL+iJH3mSETueM/XiGgL3hVTsxc20=

--- a/main/config/config_K_v.json
+++ b/main/config/config_K_v.json
@@ -146,7 +146,9 @@
             "titleChange-help": "当房间标题变化时触发，占位符{oldTitle}:旧标题(string) {newTitle}:新标题(string)",
             "titleChange": [],
             "afterRec-help": "当结束录制后(包含切片)触发对应的命令，占位符{liveDir}:录播所在目录(string)(末尾有/) {recSec}:录制时长秒数(uint)(>=0) {type}:视频类型(string)(例如mp4)",
-            "afterRec":[]
+            "afterRec":[],
+            "loginChange-help": "当登陆状态变化时触发对应的命令，占位符{newState}:新的状态(string)(true/false)",
+            "loginChange":[]
         }
     ],
     "指定房间录制区间-help":"指定roomid的房间在指定时间段内将会开启录制.start时检查是否在直播,是则开始录制,如已在录制则切片.end时停止录制.在开播时,若同时有start与end的fromTo,且当前在start与end之间,则录制,若无同时有start与end,则开播就录制。5s内只能触发一个fromTo",
@@ -239,6 +241,7 @@
     "扫码登录": false,
     "扫码登录路径": "/qr/",
     "扫码登录自动打开标签页": false,
+    "扫码登录-命令行不显示二维码": false,
     "网络中断不退出": true,
     "代理地址-help":"支持http,https,socks5。例http://127.0.0.1:38223 为空时不使用",
     "代理地址":"",


### PR DESCRIPTION
优化了登陆失效及重新登陆
### 行为

失效时：
- 程序将重新连接弹幕服务器
- 如有录制，录制将尽量持续到被中止
- 触发下述`loginChange`调用

可以通过下述方法重新登录：
- 访问扫码登录路径，触发登陆
```
README.md
(>v0.20.3)当扫码登陆为true时，未登录时访问扫码登录路径触发登陆，而不用在命令行使用 login触发
```
- 使用命令行指令` login`触发登录
- 重启程序，自动触发扫码登录

重新登录时：
- 程序将重新连接弹幕服务器
- 如有录制，录制将开始检查是否满足`直播流清晰度恢复`等配置项，如可以恢复则重启录制
- 触发下述`loginChange`调用

可以通过下述方法登出（注销）：
- 使用命令行指令` logout`

### 配置新增说明

1. 配置项添加：`指定房间回调`添加`loginChange`事件，用于提醒程序登录状态变化
```json
"loginChange-help": "当登陆状态变化时触发对应的命令，占位符{newState}:新的状态(string)(true/false)",
"loginChange":[]
```

2. 配置项添加：`扫码登录-命令行不显示二维码`，默认为false，为false登录时在命令行显示方块二维码。
当使用了其他途径扫码登录，如`扫码登录路径`，可以将此项设置为true减少日志显示
```
"扫码登录-命令行不显示二维码": false,
```

3. 命令行指令添加` logout`，一般用于调试用，用于登出当前账号，cookie将失效