### PR TITLE
Improve 优化录制锁占用

### DIFF
--- a/Reply/Reply.go
+++ b/Reply/Reply.go
@@ -988,20 +988,21 @@ func (t replyF) preparing(s []byte) {
 		msglog.E(err)
 		return
 	} else if t.Liveing {
+		t.Liveing = false
 		{ //附加功能 savestream结束
-			t.Liveing = false
-			// 停止此房间录制
-			var roomId, _ = strconv.Atoi(type_item.Roomid)
-			StreamOStop(roomId)
+			// 停止此房间录制, 异步避免长时间持有锁
+			go func(roomId int, _ error) {
+				StreamOStop(roomId)
+				replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
+					if e := inter.FiliterRoomId(t.K_v.LoadV(`指定房间回调`), roomId).Fin(); e != nil {
+						msglog.W("房间", type_item.Roomid, e)
+					}
+				})
+			}(strconv.Atoi(type_item.Roomid))
 			// 下播总结
 			if _, e := liveOver.Sumup.Run(context.Background(), t.Common); e != nil {
 				msglog.E(e)
 			}
-			go replyFunc.RoomSignal.Run2(func(inter replyFunc.RoomSignalI) {
-				if e := inter.FiliterRoomId(t.K_v.LoadV(`指定房间回调`), roomId).Fin(); e != nil {
-					msglog.W("房间", type_item.Roomid, e)
-				}
-			})
 		}
 		Gui_show("房间", type_item.Roomid, "下播了", "0room")
 		msglog.I("房间", type_item.Roomid, "下播了")

--- a/bili_danmu.go
+++ b/bili_danmu.go
@@ -503,7 +503,7 @@ func entryRoom(mainCtx context.Context, danmulog *plog.Log, common *c.Common) (e
 				})
 				time.Sleep(time.Millisecond * time.Duration(heartinterval*1000))
 				if lastReplyT := func() time.Time {
-					defer common.Lock()()
+					defer common.RLock()()
 					return common.ReplyT
 				}(); lastReplyT.IsZero() {
 					danmulog.WF("心跳无响应")


### PR DESCRIPTION
在极短时间接收到上下播消息时，录制有可能还未启动完全，而又被要求停止，概率触发死锁
```
1 @ 0x4896ee 0x4193ee 0x418f12 0xcb74aa 0xcb7466 0xc8906c 0xca2932 0xc99217 0xc99d15 0xccb3a8 0xc54872 0xccb365 0x490fa1
#	0xcb74a9	github.com/qydysky/part/signal.(*Signal).Wait+0x149		/home/runner/go/pkg/mod/github.com/qydysky/part@v0.28.20260722185429/signal/Signal.go:20
#	0xcb7465	github.com/qydysky/bili_danmu/Reply.(*M4SStream).Stop+0x105	/home/runner/work/bili_danmu/bili_danmu/Reply/stream.go:1704
#	0xc8906b	github.com/qydysky/bili_danmu/Reply.StreamOStop+0xab		/home/runner/work/bili_danmu/bili_danmu/Reply/F.go:137
#	0xca2931	github.com/qydysky/bili_danmu/Reply.replyF.preparing+0x251	/home/runner/work/bili_danmu/bili_danmu/Reply/Reply.go:995
#	0xc99216	github.com/qydysky/bili_danmu/Reply.Msg+0x256			/home/runner/work/bili_danmu/bili_danmu/Reply/Msg.go:209
#	0xc99d14	github.com/qydysky/bili_danmu/Reply.Reply+0x8b4			/home/runner/work/bili_danmu/bili_danmu/Reply/Reply.go:133
#	0xccb3a7	github.com/qydysky/bili_danmu.entryRoom.func6.1.1+0x27		/home/runner/work/bili_danmu/bili_danmu/bili_danmu.go:477
#	0xc54871	github.com/qydysky/part/websocket.(*Client).Handle.func2.4+0x71	/home/runner/go/pkg/mod/github.com/qydysky/part@v0.28.20260722185429/websocket/Client.go:240
#	0xccb364	github.com/qydysky/bili_danmu.entryRoom.func6.1+0x64		/home/runner/work/bili_danmu/bili_danmu/bili_danmu.go:476
```
```
1 @ 0x4896ee 0x466d12 0x466ce9 0x48ad85 0x49895d 0x49a0f2 0x49a0d0 0x49a0cf 0xbdd02e 0xbdd045 0xcb512d 0x490fa1
#	0x48ad84	internal/sync.runtime_SemacquireMutex+0x24				/opt/hostedtoolcache/go/1.26.5/x64/src/runtime/sema.go:95
#	0x49895c	internal/sync.(*Mutex).lockSlow+0x15c					/opt/hostedtoolcache/go/1.26.5/x64/src/internal/sync/mutex.go:149
#	0x49a0f1	internal/sync.(*Mutex).Lock+0x31					/opt/hostedtoolcache/go/1.26.5/x64/src/internal/sync/mutex.go:70
#	0x49a0cf	sync.(*Mutex).Lock+0xf							/opt/hostedtoolcache/go/1.26.5/x64/src/sync/mutex.go:46
#	0x49a0ce	sync.(*RWMutex).Lock+0xe						/opt/hostedtoolcache/go/1.26.5/x64/src/sync/rwmutex.go:150
#	0xbdd02d	github.com/qydysky/bili_danmu/CV.(*Common).Lock+0xcd			/home/runner/work/bili_danmu/bili_danmu/CV/Var.go:108
#	0xbdd044	github.com/qydysky/bili_danmu/F.(*GetFuncV2).Get+0xe4			/home/runner/work/bili_danmu/bili_danmu/F/api_v2.go:74
#	0xcb512c	github.com/qydysky/bili_danmu/Reply.(*M4SStream).Start.func1+0x58c	/home/runner/work/bili_danmu/bili_danmu/Reply/stream.go:1668
```